### PR TITLE
Adding pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.6
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,9 @@ $ pre-commit install
 $ pre-commit install --hook-type pre-commit
 ```
 
-This will then run [black]() prior to every commit and only commit the
-reformatted files. A successful pre-commit hook will show a message like:
+This will then run [black](https://black.readthedocs.io/en/stable/) prior to
+every commit and only commit the reformatted files. A successful pre-commit hook
+will show a message like:
 
 ```bash
 black....................................................................Passed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,38 @@ $ git fetch upstream
 $ git checkout -b my-new-feature upstream/master
 ```
 
+## Pre-commit hook
+PEP8 checks can be run automatically as part of a pre-commit hook. In order to
+install this pre-commit hook, run the following commands,
+
+```bash
+$ cd PTMCMCSampler
+$ pip install pre-commit
+$ pre-commit install
+$ pre-commit install --hook-type pre-commit
+```
+
+This will then run [black]() prior to every commit and only commit the
+reformatted files. A successful pre-commit hook will show a message like:
+
+```bash
+black....................................................................Passed
+[pre-commit-hook 201237f] commit message
+ 1 file changed, 6 insertions(+)
+```
+
+A failed pre-commit hook will show a message like:
+
+```bash
+black....................................................................Failed
+hookid: black
+
+error: cannot format ...
+```
+
+For a failed pre-commit hook, the file will still be commited, but will not be
+PEP8 compatible.
+
 ## Unit tests
 Unit tests and code coverage measurement are run automatically as part of the
 continuous integration (CI) for every branch and for every merge request. New

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 corner
 mpi4py
 arviz
+pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 100
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+  | profiling
+)/


### PR DESCRIPTION
The purpose of this MR is to add a pre-commit hook, which if installed, will run `black` before every commit to make sure that the added files are pep8 compatible. Instructions on how to setup this pre-commit hook are in the CONTRIBUTING.md file.